### PR TITLE
15 feature multiple data pages server side

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -9,7 +9,9 @@ export function arrayToObject(array) {
     return result;
 }
 
-export const booksURL = `${PUBLIC_APIURL}/media?apiKey=${PUBLIC_API_KEY}&facetFields%5B%5D=search_s_auteur&facetFields%5B%5D=search_s_plaats_van_uitgave&facetFields%5B%5D=search_s_jaar&facetFields%5B%5D=search_s_digitized_publication&fq%5B%5D=search_s_digitized_publication:%22Ja%22&lang=nl&page=1&q=&rows=25&sort=random%7B1709035870679%7D+asc`;
+const nRows = 25;
+
+export const booksURL = `${PUBLIC_APIURL}/media?apiKey=${PUBLIC_API_KEY}&facetFields%5B%5D=search_s_auteur&facetFields%5B%5D=search_s_plaats_van_uitgave&facetFields%5B%5D=search_s_jaar&facetFields%5B%5D=search_s_digitized_publication&fq%5B%5D=search_s_digitized_publication:%22Ja%22&lang=nl&page=1&q=&rows=${nRows}&sort=random%7B1709035870679%7D+asc`;
 
 // TODO: Add filters as arguments
 export async function getBooks(pageNr, customFetch = null) {
@@ -17,7 +19,7 @@ export async function getBooks(pageNr, customFetch = null) {
 
 	const res = await (customFetch ?? fetch)(query);
     const data = await res.json();
-    return data.media.map((book) =>{
+    const books = data.media.map((book) =>{
         const meta = arrayToObject(book.metadata, 'value')
         return {
             title: book.title,
@@ -25,4 +27,8 @@ export async function getBooks(pageNr, customFetch = null) {
             publicationYear: meta.jaar
         }
     });
+    return {
+        totalPages: Math.ceil(data.metadata.pagination.total / nRows),
+        books
+    }
 }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,3 +1,5 @@
+import { PUBLIC_APIURL, PUBLIC_API_KEY } from '$env/static/public';
+
 // place files you want to import through the `$lib` alias in this folder.
 export function arrayToObject(array) {
     const result = {};
@@ -5,4 +7,22 @@ export function arrayToObject(array) {
         result[entry.field] = entry.value;
     }
     return result;
+}
+
+export const booksURL = `${PUBLIC_APIURL}/media?apiKey=${PUBLIC_API_KEY}&facetFields%5B%5D=search_s_auteur&facetFields%5B%5D=search_s_plaats_van_uitgave&facetFields%5B%5D=search_s_jaar&facetFields%5B%5D=search_s_digitized_publication&fq%5B%5D=search_s_digitized_publication:%22Ja%22&lang=nl&page=1&q=&rows=25&sort=random%7B1709035870679%7D+asc`;
+
+// TODO: Add filters as arguments
+export async function getBooks(pageNr, customFetch = null) {
+    let query = booksURL + '&page=' + pageNr;
+
+	const res = await (customFetch ?? fetch)(query);
+    const data = await res.json();
+    return data.media.map((book) =>{
+        const meta = arrayToObject(book.metadata, 'value')
+        return {
+            title: book.title,
+            author: meta.auteur,
+            publicationYear: meta.jaar
+        }
+    });
 }

--- a/src/lib/paginated-view.svelte
+++ b/src/lib/paginated-view.svelte
@@ -1,7 +1,7 @@
 <script>
     /** @type {import('./$types').PageData} */
     // name must be unique. It is used for the no-js version to ensure that different instances of this component don't conflict.
-    let { pageNr = $bindable(), name } = $props(); // https://svelte.dev/docs/svelte/$bindable
+    let { pageNr = $bindable(), totalPages, name } = $props(); // https://svelte.dev/docs/svelte/$bindable
 
     async function nextPage(event) {
         event.preventDefault();
@@ -14,9 +14,10 @@
     }
 </script>
 
+<div>{pageNr}/{totalPages}</div>
 <form action="/digital-catalog">
     <!-- TODO: Add more hidden inputs containing the current filters sothat they are not removed when navigating -->
     <input type="hidden" name="{name}-page" value={pageNr}>
     <input type="submit" name="{name}-page-action" value="previous" onclick={previousPage} disabled={pageNr <= 1}>
-    <input type="submit" name="{name}-page-action" value="next" onclick={nextPage}>
+    <input type="submit" name="{name}-page-action" value="next" onclick={nextPage} disabled={pageNr >= totalPages}>
 </form>

--- a/src/lib/paginated-view.svelte
+++ b/src/lib/paginated-view.svelte
@@ -1,0 +1,22 @@
+<script>
+    /** @type {import('./$types').PageData} */
+    // name must be unique. It is used for the no-js version to ensure that different instances of this component don't conflict.
+    let { pageNr = $bindable(), name } = $props(); // https://svelte.dev/docs/svelte/$bindable
+
+    async function nextPage(event) {
+        event.preventDefault();
+        pageNr++;
+    }
+
+    async function previousPage(event) {
+        event.preventDefault();
+        pageNr--;
+    }
+</script>
+
+<form action="/digital-catalog">
+    <!-- TODO: Add more hidden inputs containing the current filters sothat they are not removed when navigating -->
+    <input type="hidden" name="{name}-page" value={pageNr}>
+    <input type="submit" name="{name}-page-action" value="previous" onclick={previousPage} disabled={pageNr <= 1}>
+    <input type="submit" name="{name}-page-action" value="next" onclick={nextPage}>
+</form>

--- a/src/routes/digital-catalog/+page.js
+++ b/src/routes/digital-catalog/+page.js
@@ -11,10 +11,11 @@ export async function load({ url, fetch }) {
 		resultsPage--
 	}
 
-	const books = await getBooks(resultsPage, fetch);
+	const { books, totalPages } = await getBooks(resultsPage, fetch);
 
 	return {
 		books,
-		resultsPage
+		resultsPage,
+		totalPages
 	}
 }

--- a/src/routes/digital-catalog/+page.js
+++ b/src/routes/digital-catalog/+page.js
@@ -1,19 +1,20 @@
 /** @type {import('./$types').PageLoad} */
-import { PUBLIC_APIURL } from '$env/static/public';
-import { arrayToObject } from '$lib';
+import { getBooks } from '$lib';
 
-export async function load({ fetch }) {
-	console.log(PUBLIC_APIURL)
-	const res = await fetch(PUBLIC_APIURL)
-	const data = await res.json()
+export async function load({ url, fetch }) {
+
+	let resultsPage = parseInt(url.searchParams.get('results-page')) || 1;
+	const resultsPageAction = url.searchParams.get('results-page-action');
+	if (resultsPageAction === 'next') {
+		resultsPage++;
+	} else if (resultsPageAction === 'previous') {
+		resultsPage--
+	}
+
+	const books = await getBooks(resultsPage, fetch);
+
 	return {
-		books: data.media.map((book) =>{
-			const meta = arrayToObject(book.metadata)
-			return {
-				title: book.title,
-				author: meta.auteur,
-				publicationYear: meta.jaar
-			}
-		})
-	};
+		books,
+		resultsPage
+	}
 }

--- a/src/routes/digital-catalog/+page.svelte
+++ b/src/routes/digital-catalog/+page.svelte
@@ -7,10 +7,11 @@
 
 	let resultsPage = $state(data.resultsPage);
 	let books = $state(data.books);
+	let totalPages = data.totalPages;
 
 	// $effect means this anonymous function will be called every time resultsPage is updated
 	$effect(async () => { // https://svelte.dev/docs/svelte/$effect
-		books = await getBooks(resultsPage);
+		books = (await getBooks(resultsPage)).books;
 	})
 </script>
 <h1>Blog</h1>
@@ -20,7 +21,7 @@
 </noscript>
 
 <!-- bind: allows PaginatedView to update the value of resultsPage -->
-<PaginatedView bind:pageNr={resultsPage} name="results" />
+<PaginatedView bind:pageNr={resultsPage} name="results" totalPages={totalPages} />
 <table>
 	<thead>
 		<tr>

--- a/src/routes/digital-catalog/+page.svelte
+++ b/src/routes/digital-catalog/+page.svelte
@@ -1,11 +1,48 @@
 <script>
+  	import { getBooks } from '$lib';
+
 	/** @type {import('./$types').PageData} */
-	export let data;
+	let { data } = $props();
+
+	let resultsPage = $state(data.resultsPage);
+	let books = $state(data.books);
+
+	async function nextResultsPage(event) {
+		event.preventDefault();
+		resultsPage++;
+		books = await getBooks(resultsPage);
+	}
+
+	async function previousResultsPage(event) {
+		event.preventDefault();
+		resultsPage--;
+		books = await getBooks(resultsPage);
+	}
 </script>
 <h1>Blog</h1>
+
+<noscript>
+	JAVASCRIPT DISABLED
+</noscript>
+
+<section id="results-nav">
+	<form action="/digital-catalog">
+		<!-- TODO: Add more hidden inputs containing the current filters sothat they are not removed when navigating -->
+		<input type="hidden" name="results-page" value={resultsPage}>
+		<input type="submit" name="results-page-action" value="previous" onclick={previousResultsPage}>
+		<input type="submit" name="results-page-action" value="next" onclick={nextResultsPage}>
+	</form>
+</section>
 <table>
+	<thead>
+		<tr>
+			<th>Titel</th>
+			<th>Auteur</th>
+			<th>Publicatie jaar</th>
+		</tr>
+	</thead>
 	<tbody>
-		{#each data.books as book}
+		{#each books as book}
 			<tr>
 				<td>{book.title}</td>
 				<td>{book.author}</td>
@@ -15,5 +52,23 @@
 	</tbody>
 	</table>
 <style>
-	
+	table, td, th {
+		border: none;
+		border-collapse: collapse;
+	}
+	thead, thead tr, th {
+		background-color: #ccc;
+	}
+
+	tbody tr:nth-of-type(even) td {
+		background-color: #eee;
+	}
+
+	th {
+		text-align: left;
+	}
+
+	td {
+		padding-right: 1em;
+	}
 </style>

--- a/src/routes/digital-catalog/+page.svelte
+++ b/src/routes/digital-catalog/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   	import { getBooks } from '$lib';
+  	import PaginatedView from '$lib/paginated-view.svelte';
 
 	/** @type {import('./$types').PageData} */
 	let { data } = $props();
@@ -7,17 +8,10 @@
 	let resultsPage = $state(data.resultsPage);
 	let books = $state(data.books);
 
-	async function nextResultsPage(event) {
-		event.preventDefault();
-		resultsPage++;
+	// $effect means this anonymous function will be called every time resultsPage is updated
+	$effect(async () => { // https://svelte.dev/docs/svelte/$effect
 		books = await getBooks(resultsPage);
-	}
-
-	async function previousResultsPage(event) {
-		event.preventDefault();
-		resultsPage--;
-		books = await getBooks(resultsPage);
-	}
+	})
 </script>
 <h1>Blog</h1>
 
@@ -25,14 +19,8 @@
 	JAVASCRIPT DISABLED
 </noscript>
 
-<section id="results-nav">
-	<form action="/digital-catalog">
-		<!-- TODO: Add more hidden inputs containing the current filters sothat they are not removed when navigating -->
-		<input type="hidden" name="results-page" value={resultsPage}>
-		<input type="submit" name="results-page-action" value="previous" onclick={previousResultsPage}>
-		<input type="submit" name="results-page-action" value="next" onclick={nextResultsPage}>
-	</form>
-</section>
+<!-- bind: allows PaginatedView to update the value of resultsPage -->
+<PaginatedView bind:pageNr={resultsPage} name="results" />
 <table>
 	<thead>
 		<tr>


### PR DESCRIPTION
## Adds a next and previous button that go to the next result page
<img width="1439" alt="Scherm­afbeelding 2025-05-02 om 15 51 42" src="https://github.com/user-attachments/assets/0f6da3bd-3d73-4728-a11f-91bbe444b482" />

Resolves issue #15 

To load all of the data without an infinite scroll, we needed to have a button to go to the next page. The infinite scroll the old page had was not great, because it was really hard to go to the footer. Thats why we decided to skip the infinite scroll. This version works with and without javascript. Without js, the input form sends a request to the server to load in the page number, and add or remove one number via server side js. With js, the same thing happens but client side, which means the page does not have to be reloaded. The buttons are in a component so they can be used in the filters as well. 

## Code documentation:
### Index.js
I added a helper function called `getBooks` to this file which loads the books. This was done to get rid of duplicated code. As the `TODO` says, parameters for sorting and filtering should be added to this function when those branches are merged. 
I used customFetch to use svelte's better version of fetch; [source](https://svelte.dev/docs/kit/load#Making-fetch-requests)
When you use the normal fetch inside +page.js, you get a warning, so this is mostly to get rid of that warning. If no customFetch is given, it falls back to the normal fetch function.
The custom fetch returns a response with the book data, after which the arrayToObject function is used to put the data in a more usable format.
The getBooks function returns an object containing the books and the total number of pages, which is the total number of books devided by the number of rows, using a math.ceil function so that the number is rounded up. 
```js
const nRows = 25;

// TODO: Add filters as arguments
export async function getBooks(pageNr, customFetch = null) {
    let query = booksURL + '&page=' + pageNr;

	const res = await (customFetch ?? fetch)(query);
    const data = await res.json();
    const books = data.media.map((book) =>{
        const meta = arrayToObject(book.metadata, 'value')
        return {
            title: book.title,
            author: meta.auteur,
            publicationYear: meta.jaar
        }
    });
    return {
        totalPages: Math.ceil(data.metadata.pagination.total / nRows),
        books
    }
}
```
### Page.js
This code loads in the current page of books. If the url looks like "?results-page=4&results-page-action=next" it will load in the next page (page 5 in this case). If `results-page` is empty or not a valid number, it defaults to page 1.

```js
let resultsPage = parseInt(url.searchParams.get('results-page')) || 1;
const resultsPageAction = url.searchParams.get('results-page-action');
if (resultsPageAction === 'next') {
	resultsPage++;
} else if (resultsPageAction === 'previous') {
	resultsPage--;
}

const { books, totalPages } = await getBooks(resultsPage, fetch);
```
### Paginated-view.svelte
This Svelte component provides a client-side and server-compatible pagination control. It allows users to navigate through pages using a form, with support for JavaScript and no-JavaScript environments.
```svelte
    // name must be unique. It is used for the no-js version to ensure that different instances of this component don't conflict.
    let { pageNr = $bindable(), totalPages, name } = $props(); // https://svelte.dev/docs/svelte/$bindable
```
The properties are
- `pageNr` is the current page number. Normally, only the parent can change and the child can read, but when `bind:` is used, the child can also modify it.
- `totalPages` is simply the total number of pages. The parent can update this number, but the child cannot
- `name` is a string that should be unique. This is used in the url parameters.

```svelte
<form action="/digital-catalog">
    <!-- TODO: Add more hidden inputs containing the current filters sothat they are not removed when navigating -->
    <input type="hidden" name="{name}-page" value={pageNr}>
    <input type="submit" name="{name}-page-action" value="previous" onclick={previousPage} disabled={pageNr <= 1}>
    <input type="submit" name="{name}-page-action" value="next" onclick={nextPage} disabled={pageNr >= totalPages}>
</form>
```
When js is disabled, clicking the `next` button submits the form with a hidden field with the current page number (for example 3). The url is changed to `?{name}-page=3&{name}-page-action=next`. `+page.js` should then load in the next page server-side.
```svelte
async function nextPage(event) {
    event.preventDefault();
    pageNr++;
}
```
When js is enabled, clicking the `next` button calls the `nextPage` function. The event is prevented to stop the form from being submitted, and the pageNr is incremented. The parent component should listen for this variable to change and update the results.

### Page.svelte
```svelte
<script>
  	import { getBooks } from '$lib';
  	import PaginatedView from '$lib/paginated-view.svelte';

	/** @type {import('./$types').PageData} */
	let { data } = $props();

	let resultsPage = $state(data.resultsPage);
	let books = $state(data.books);
	let totalPages = data.totalPages;

	// $effect means this anonymous function will be called every time resultsPage is updated
	$effect(async () => { // https://svelte.dev/docs/svelte/$effect
		books = (await getBooks(resultsPage)).books;
	})
</script>
<h1>Blog</h1>

<noscript>
	JAVASCRIPT DISABLED
</noscript>

<!-- bind: allows PaginatedView to update the value of resultsPage -->
<PaginatedView bind:pageNr={resultsPage} name="results" totalPages={totalPages} />
<table>
	<thead>
		<tr>
			<th>Titel</th>
			<th>Auteur</th>
			<th>Publicatie jaar</th>
		</tr>
	</thead>
	<tbody>
		{#each books as book}
			<tr>
				<td>{book.title}</td>
				<td>{book.author}</td>
				<td>{book.publicationYear}</td>
			</tr>
		{/each}
	</tbody>
</table>
```
This page uses the `PaginatedView` component. `resultsPage` is initially set to the number recieved from `+page.js`, and then bound to the component. `$effect` creates a function which is called whenever a `$state` variable inside it updates. In this case, the only `$state` variable used in the anonymous function is `resultsPage`. When that number changes, the new page of books is loaded in.

## How Has This Been Tested?

- [x] Accessibility test

### Tabtest:

https://github.com/user-attachments/assets/d7714138-eadc-4c04-ad8a-d9e7830829c0



## How to review

Open the branch with this code and click the next and previous buttons, to see if they work. Also disable javascript to see if they still work. 
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
