### PR TITLE
36 feature preserve fields places filter

### DIFF
--- a/src/lib/filter-button-publication-place.svelte
+++ b/src/lib/filter-button-publication-place.svelte
@@ -2,7 +2,7 @@
     /** @type {import('./$types').PageData} */
     import { placesURL } from "$lib";
     import PaginatedView from "./paginated-view.svelte";
-    let { publicationPlace = $bindable(), publicationPlaces, placesPage, filterPlace } = $props();
+    let { publicationPlace = $bindable(), publicationPlaces, placesPage } = $props();
 
     $effect(async () => {
         const resPlaces = await fetch(placesURL + '&page=' + placesPage);
@@ -15,6 +15,7 @@
     <PaginatedView name="places" bind:pageNr={placesPage} totalPages="TODO"/>
     <form action="/digital-catalog">
         <div id="place-filter-list">
+            <!-- bind:group means that publicationPlace will be automatically updated when the user clicks on a radio input -->
             {#each publicationPlaces as place}
                 <input
                     class="place-radio"
@@ -27,8 +28,9 @@
                 <label
                     class="place-label"
                     for="place-{place.id}"
-                    >{place.label} ({place.count})</label
                 >
+                    {place.label} ({place.count})
+                </label>
             {/each}
         </div>
         <noscript>
@@ -36,12 +38,6 @@
         </noscript>
     </form>
 </details>
-{#if filterPlace}
-<div>
-    <button onclick={clearPlaceFilter}>X</button>
-    { filterPlace }
-</div>
-{/if}
 
 <style>
     #place-filter-list {

--- a/src/lib/filter-button-publication-place.svelte
+++ b/src/lib/filter-button-publication-place.svelte
@@ -1,49 +1,64 @@
 <script>
     /** @type {import('./$types').PageData} */
-    let {publicationPlaces, publicationPlace = $bindable() } = $props();
+    import { placesURL } from "$lib";
+    import PaginatedView from "./paginated-view.svelte";
+    let { publicationPlace = $bindable(), publicationPlaces, placesPage, filterPlace } = $props();
 
-    function applyFilter(event) {
-        // TODO: fetch api, update publicationPlaces
-    }
+    $effect(async () => {
+        const resPlaces = await fetch(placesURL + '&page=' + placesPage);
+        const dataPlaces = await resPlaces.json();
+        publicationPlaces = dataPlaces.filter;
+    })
 </script>
 
-<a href="/digital-catalog">Clear</a>
-<form action="/digital-catalog">
-    <div id="publicationPlace-filter-list">
-        {#each publicationPlaces as place}
-            <input
-                class="publicationPlace-radio"
-                value={place.id}
-                id="publicationPlace-{place.id}"
-                type="radio"
-                name="publicationPlace"
-            />
-            <label
-                class="publicationPlace-label"
-                for="publicationPlace-{place.id}"
-                >{place.label} ({place.count})</label
-            >
-        {/each}
-    </div>
-    <button type="submit">Filter</button>
-</form>
+<details>
+    <PaginatedView name="places" bind:pageNr={placesPage} totalPages="TODO"/>
+    <form action="/digital-catalog">
+        <div id="place-filter-list">
+            {#each publicationPlaces as place}
+                <input
+                    class="place-radio"
+                    value={place.id}
+                    id="place-{place.id}"
+                    type="radio"
+                    name="place"
+                    bind:group={publicationPlace}
+                />
+                <label
+                    class="place-label"
+                    for="place-{place.id}"
+                    >{place.label} ({place.count})</label
+                >
+            {/each}
+        </div>
+        <noscript>
+            <button type="submit">Filter</button>
+        </noscript>
+    </form>
+</details>
+{#if filterPlace}
+<div>
+    <button onclick={clearPlaceFilter}>X</button>
+    { filterPlace }
+</div>
+{/if}
 
 <style>
-    #publicationPlace-filter-list {
+    #place-filter-list {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
         grid-template-rows: repeat(15, 1fr);
     }
 
-    .publicationPlace-radio {
+    .place-radio {
         display: none;
     }
 
-    .publicationPlace-radio:checked + .publicationPlace-label {
+    .place-radio:checked + .place-label {
         color: red;
     }
 
-    .publicationPlace-label {
+    .place-label {
         cursor: pointer;
     }
 </style>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,6 +1,6 @@
 import { PUBLIC_APIURL, PUBLIC_API_KEY } from '$env/static/public';
 
-// place files you want to import through the `$lib` alias in this folder.
+// Converts the data to a more usable format
 export function arrayToObject(array, valueField) {
     const result = {};
     for (const entry of array) {
@@ -11,10 +11,11 @@ export function arrayToObject(array, valueField) {
 
 const nRows = 25;
 
+// The urls now show all the data, not filtered on ditialized books anymore
 export const booksURL = `${PUBLIC_APIURL}/media?apiKey=${PUBLIC_API_KEY}&facetFields%5B%5D=search_s_auteur&facetFields%5B%5D=search_s_plaats_van_uitgave&facetFields%5B%5D=search_s_jaar&facetFields%5B%5D=search_s_digitized_publication&lang=nl&page=1&q=&rows=${nRows}&sort=random%7B1709035870679%7D+asc`;
 export const placesURL = `${PUBLIC_APIURL}/filter/search_s_plaats_van_uitgave?ac=&apiKey=${PUBLIC_API_KEY}&facetFields%5B%5D=search_s_auteur&facetFields%5B%5D=search_s_plaats_van_uitgave&facetFields%5B%5D=search_s_jaar&facetFields%5B%5D=search_s_digitized_publication&facetSort=count&lang=nl&page=1&rows=45`;
 
-// TODO: Add filters as arguments
+// GET function for books and filters
 export async function getBooks(pageNr, publicationPlace, customFetch = null) {
     let query = booksURL + '&page=' + pageNr;
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -11,8 +11,8 @@ export function arrayToObject(array, valueField) {
 
 const nRows = 25;
 
-export const booksURL = `${PUBLIC_APIURL}/media?apiKey=${PUBLIC_API_KEY}&facetFields%5B%5D=search_s_auteur&facetFields%5B%5D=search_s_plaats_van_uitgave&facetFields%5B%5D=search_s_jaar&facetFields%5B%5D=search_s_digitized_publication&fq%5B%5D=search_s_digitized_publication:%22Ja%22&lang=nl&page=1&q=&rows=${nRows}&sort=random%7B1709035870679%7D+asc`;
-export const placesURL = `${PUBLIC_APIURL}/filter/search_s_plaats_van_uitgave?ac=&apiKey=${PUBLIC_API_KEY}&facetFields%5B%5D=search_s_auteur&facetFields%5B%5D=search_s_plaats_van_uitgave&facetFields%5B%5D=search_s_jaar&facetFields%5B%5D=search_s_digitized_publication&facetSort=index&lang=nl&page=1&q=&rows=45`;
+export const booksURL = `${PUBLIC_APIURL}/media?apiKey=${PUBLIC_API_KEY}&facetFields%5B%5D=search_s_auteur&facetFields%5B%5D=search_s_plaats_van_uitgave&facetFields%5B%5D=search_s_jaar&facetFields%5B%5D=search_s_digitized_publication&lang=nl&page=1&q=&rows=${nRows}&sort=random%7B1709035870679%7D+asc`;
+export const placesURL = `${PUBLIC_APIURL}/filter/search_s_plaats_van_uitgave?ac=&apiKey=${PUBLIC_API_KEY}&facetFields%5B%5D=search_s_auteur&facetFields%5B%5D=search_s_plaats_van_uitgave&facetFields%5B%5D=search_s_jaar&facetFields%5B%5D=search_s_digitized_publication&facetSort=count&lang=nl&page=1&rows=45`;
 
 // TODO: Add filters as arguments
 export async function getBooks(pageNr, publicationPlace, customFetch = null) {

--- a/src/lib/paginated-view.svelte
+++ b/src/lib/paginated-view.svelte
@@ -1,8 +1,8 @@
 <script>
     /** @type {import('./$types').PageData} */
     // name must be unique. It is used for the no-js version to ensure that different instances of this component don't conflict.
-    // preservedFields is a object containing the url search parameters that should be preserved when navigating through the pages.
-    let { pageNr = $bindable(), totalPages, name, preservedFields = {} } = $props(); // https://svelte.dev/docs/svelte/$bindable
+    // preservedFields is an object containing the url search parameters that should be preserved when navigating through the pages.
+    let { pageNr = $bindable(), totalPages, name, preservedFields = {} } = $props();
 
     async function nextPage(event) {
         event.preventDefault();
@@ -16,6 +16,7 @@
 </script>
 
 <div>{pageNr}/{totalPages}</div>
+<!-- Object entries transforms an object into an array of key-value pairs -->
 <form action="/digital-catalog">
     {#each Object.entries(preservedFields) as [name, value]}
         <input type="hidden" name={name} value={value}>

--- a/src/lib/paginated-view.svelte
+++ b/src/lib/paginated-view.svelte
@@ -1,7 +1,8 @@
 <script>
     /** @type {import('./$types').PageData} */
     // name must be unique. It is used for the no-js version to ensure that different instances of this component don't conflict.
-    let { pageNr = $bindable(), totalPages, name } = $props(); // https://svelte.dev/docs/svelte/$bindable
+    // preservedFields is a object containing the url search parameters that should be preserved when navigating through the pages.
+    let { pageNr = $bindable(), totalPages, name, preservedFields = {} } = $props(); // https://svelte.dev/docs/svelte/$bindable
 
     async function nextPage(event) {
         event.preventDefault();
@@ -16,7 +17,9 @@
 
 <div>{pageNr}/{totalPages}</div>
 <form action="/digital-catalog">
-    <!-- TODO: Add more hidden inputs containing the current filters sothat they are not removed when navigating -->
+    {#each Object.entries(preservedFields) as [name, value]}
+        <input type="hidden" name={name} value={value}>
+    {/each}
     <input type="hidden" name="{name}-page" value={pageNr}>
     <input type="submit" name="{name}-page-action" value="previous" onclick={previousPage} disabled={pageNr <= 1}>
     <input type="submit" name="{name}-page-action" value="next" onclick={nextPage} disabled={pageNr >= totalPages}>

--- a/src/routes/digital-catalog/+page.js
+++ b/src/routes/digital-catalog/+page.js
@@ -3,6 +3,7 @@ import { PUBLIC_APIURL, PUBLIC_API_KEY } from '$env/static/public';
 import { getBooks, placesURL } from '$lib';
 
 export async function load({ url, fetch }) {
+	// Pagination for results
 	let resultsPage = parseInt(url.searchParams.get('results-page')) || 1;
 	const resultsPageAction = url.searchParams.get('results-page-action');
 	if (resultsPageAction === 'next') {
@@ -11,19 +12,19 @@ export async function load({ url, fetch }) {
 		resultsPage--;
 	}
 
+	// Filtering
 	const publicationPlace = url.searchParams.get('place');
 
 	const { books, totalPages } = await getBooks(resultsPage, publicationPlace, fetch);
 
-	 let placesPage = parseInt(url.searchParams.get('places-page')) || 1;
+	// Pagination for places
+	let placesPage = parseInt(url.searchParams.get('places-page')) || 1;
     const placesPageAction = url.searchParams.get('places-page-action');
     if (placesPageAction === 'next') {
         placesPage++;
     } else if (placesPageAction === 'previous') {
         placesPage--;
     }
-
-
 
 	const resPlaces = await fetch(placesURL + '&page=' + placesPage);
     const dataPlaces = await resPlaces.json();

--- a/src/routes/digital-catalog/+page.js
+++ b/src/routes/digital-catalog/+page.js
@@ -3,16 +3,15 @@ import { PUBLIC_APIURL, PUBLIC_API_KEY } from '$env/static/public';
 import { getBooks, placesURL } from '$lib';
 
 export async function load({ url, fetch }) {
-
 	let resultsPage = parseInt(url.searchParams.get('results-page')) || 1;
 	const resultsPageAction = url.searchParams.get('results-page-action');
 	if (resultsPageAction === 'next') {
 		resultsPage++;
 	} else if (resultsPageAction === 'previous') {
-		resultsPage--
+		resultsPage--;
 	}
 
-	const publicationPlace = url.searchParams.get('publicationPlace');
+	const publicationPlace = url.searchParams.get('place');
 
 	const { books, totalPages } = await getBooks(resultsPage, publicationPlace, fetch);
 
@@ -24,9 +23,12 @@ export async function load({ url, fetch }) {
         placesPage--;
     }
 
+
+
 	const resPlaces = await fetch(placesURL + '&page=' + placesPage);
     const dataPlaces = await resPlaces.json();
     const places = dataPlaces.filter;
+
     return {
         books,
         resultsPage,

--- a/src/routes/digital-catalog/+page.svelte
+++ b/src/routes/digital-catalog/+page.svelte
@@ -1,18 +1,21 @@
 <script>
 	import { getBooks } from '$lib';
   	import PaginatedView from '$lib/paginated-view.svelte';
-
 	import FilterButtonPublicationPlace from "$lib/filter-button-publication-place.svelte";
+
 	/** @type {import('./$types').PageData} */
 	let { data } = $props();
 
 	let resultsPage = $state(data.resultsPage);
 	let books = $state(data.books);
-	let totalPages = data.totalPages;
+	let totalPages = $state(data.totalPages);
+	let publicationPlace = $state(data.publicationPlace)
 
 	// $effect means this anonymous function will be called every time resultsPage is updated
 	$effect(async () => { // https://svelte.dev/docs/svelte/$effect
-		books = (await getBooks(resultsPage)).books;
+		const res = await getBooks(resultsPage, publicationPlace);
+		books = res.books;
+		totalPages = res.totalPages	
 	})
 </script>
 
@@ -22,10 +25,10 @@
 	JAVASCRIPT DISABLED
 </noscript>
 
-<FilterButtonPublicationPlace bind:publicationPlace={data.publicationPlace} publicationPlaces={data.places} placePage={data.placesPage}/>
+<FilterButtonPublicationPlace bind:publicationPlace={publicationPlace} publicationPlaces={data.places} placesPage={data.placesPage}/>
 
 <!-- bind: allows PaginatedView to update the value of resultsPage -->
-<PaginatedView bind:pageNr={resultsPage} name="results" totalPages={totalPages} />
+<PaginatedView bind:pageNr={resultsPage} name="results" totalPages={totalPages} preservedFields={{place: publicationPlace}} />
 
 <table>
 	<thead>

--- a/src/routes/digital-catalog/+page.svelte
+++ b/src/routes/digital-catalog/+page.svelte
@@ -6,17 +6,18 @@
 	/** @type {import('./$types').PageData} */
 	let { data } = $props();
 
+	// The following variables are updated and are therefore declared with $state
 	let resultsPage = $state(data.resultsPage);
 	let books = $state(data.books);
 	let totalPages = $state(data.totalPages);
-	let publicationPlace = $state(data.publicationPlace)
+	let publicationPlace = $state(data.publicationPlace);
 
-	// $effect means this anonymous function will be called every time resultsPage is updated
-	$effect(async () => { // https://svelte.dev/docs/svelte/$effect
+	// $effect means this anonymous function will be called every time any of the $state variables inside are updated
+	$effect(async () => {
 		const res = await getBooks(resultsPage, publicationPlace);
 		books = res.books;
-		totalPages = res.totalPages	
-	})
+		totalPages = res.totalPages;
+	});
 </script>
 
 <h1>Blog</h1>


### PR DESCRIPTION
## What does this change?

Resolves issue #36 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

I fixed the merge issues, by using the code from the author filter which had the same issues. For this I've added missing bits of pagination code in the page.js, as well as make the place filter bindable, so it can be automatically updated. 

After this, the filter worked again, however, clicking next or previous page would resend the form request, and thus refreshing the page. This made the place filter dissappear everytime you wanted to scroll through the results across multiple pages. 

For this I made a PreservedFields property, which makes sure the fields in the url are not removed. (Or actually, it re adds it.) This works by having a hidden input field inside the form with the name and value of the field you want to preserve. This gets submitted when the form gets submitted, and then the value of that field is in the url. 

### Other mentionable changes:
- I've changed the url's so that they now load ALL the books, not just the ones that are digitalized. This fixes the issue of the filter showing it has a certain amount of results, and then not seeing the results because they are filtered as digitalized, and the real results were not digitalized. 
- I've changed some names to make them shorter, mainly in the page.js for the places pagination, to make the url shorter.
- I've changed some names from camelCase to kebab-case, mainly in filter.svelte for class names, attributes and in the CSS.